### PR TITLE
Initialize load testing orchestrator application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,118 @@
-# LAloadtest
+# Middleware Load Test Orchestrator
+
+This project provides a FastAPI application that orchestrates configurable load tests for middleware systems exposed through Azure API Management or any other HTTP endpoint. It is designed to help you drive asynchronous end-to-end flows that rely on correlation tokens and callbacks, while giving you live visibility into execution progress and timing metrics.
+
+## Key capabilities
+
+- Define reusable test scenarios that describe the downstream endpoint, HTTP method, payload, headers, call rate (per minute) and duration.
+- Automatically inject a unique `correlation_token` into each outbound request (JSON body for non-`GET` requests and query parameters for `GET`) and expose it through the `X-Correlation-Token` header.
+- Receive asynchronous callbacks from the system under test and match them to their originating requests using the correlation token.
+- Track per-call status, outstanding requests, and aggregate statistics such as success rate, throughput, and response time distribution (min/max/average/median).
+- Stream live metrics over WebSockets so you can build real-time dashboards during a load test.
+
+## Project structure
+
+```
+app/
+├── __init__.py
+├── main.py           # FastAPI entry point
+├── models.py         # Pydantic models and enums
+└── orchestrator.py   # Core orchestration engine
+
+tests/
+└── test_orchestrator.py
+```
+
+## Getting started
+
+1. **Create and activate a virtual environment (recommended):**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. **Install dependencies:**
+   ```bash
+   pip install -e .[dev]
+   ```
+
+3. **Run the API server:**
+   ```bash
+   uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+   ```
+
+   The application requires outbound internet access so that it can reach the target endpoints you configure. When running locally ensure your network allows the necessary traffic.
+
+4. **Interact with the API:**
+   - Open the automatically generated API docs at `http://localhost:8000/docs` to explore and invoke endpoints.
+   - Use the `/tests` endpoints to create, start, stop, and inspect load tests.
+   - Subscribe to real-time updates via WebSocket at `ws://localhost:8000/ws/tests/{test_id}`.
+   - Point your downstream service callbacks to `POST http://localhost:8000/callbacks` and include the `correlation_token` returned in each outbound request.
+
+## Defining and running tests
+
+To define a test, POST to `/tests` with a payload such as:
+
+```json
+{
+  "name": "evening-peak",
+  "target_url": "https://<your-api-management-endpoint>/api/process",
+  "method": "POST",
+  "rate_per_minute": 120,
+  "duration_seconds": 600,
+  "headers": {
+    "Ocp-Apim-Subscription-Key": "<subscription-key>"
+  },
+  "payload": {
+    "message": "hello from orchestrator"
+  },
+  "start_immediately": true
+}
+```
+
+Each outbound call will carry the generated correlation token in the request body (as `correlation_token`) and the `X-Correlation-Token` header. When your middleware completes processing, it should call back:
+
+```http
+POST /callbacks
+Content-Type: application/json
+
+{
+  "correlation_token": "<token from request>",
+  "status": "success",
+  "code": 202,
+  "detail": {
+    "received": "2024-01-01T12:34:56Z"
+  }
+}
+```
+
+`status` and `code` are optional but help the orchestrator determine whether a callback represents success or failure. Any additional properties are stored for inspection.
+
+### Monitoring live progress
+
+Connect to the WebSocket endpoint for a test to receive periodic JSON payloads containing:
+
+- Current status (`pending`, `running`, `completed`, `failed`, `cancelled`)
+- Counts for total sent, dispatched, completed, failed, and pending calls
+- Success rate and average throughput time
+- Response time statistics (min/max/average/median in milliseconds)
+- Outstanding correlation tokens that are still awaiting callbacks (truncated to 50 entries)
+
+These updates can be used to power dashboards or feed alerting workflows during a load test.
+
+## Running tests
+
+Execute the automated test suite with:
+
+```bash
+pytest
+```
+
+The tests mock outbound HTTP dispatches to ensure they run quickly without requiring external services.
+
+## Next steps
+
+- Integrate the WebSocket stream with your preferred visualization framework to build custom charts.
+- Extend the payload templating logic if you need to shape requests differently for each call (e.g., per-user data).
+- Persist test definitions or results to a database or message queue if you require long-term storage beyond the in-memory orchestrator.
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,7 @@
+"""Application package for the load test orchestrator."""
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,125 @@
+"""FastAPI application exposing the load test orchestrator."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
+from fastapi.encoders import jsonable_encoder
+
+from . import __version__
+from .models import (
+    CallListResponse,
+    CallbackPayload,
+    CallbackReceipt,
+    TestConfig,
+    TestListResponse,
+    TestSummary,
+)
+from .orchestrator import TestOrchestrator
+
+app = FastAPI(title="Middleware Load Test Orchestrator", version=__version__)
+orchestrator = TestOrchestrator()
+
+
+async def _get_test_summary_or_404(test_id: UUID) -> TestSummary:
+    try:
+        return await orchestrator.get_summary(test_id)
+    except KeyError as exc:  # pragma: no cover - FastAPI handles HTTPException conversion
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+async def _get_test_or_404(test_id: UUID):
+    try:
+        return orchestrator.get_test(test_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.get("/", response_model=dict)
+async def root() -> dict:
+    """Basic health endpoint."""
+    return {"service": app.title, "version": app.version}
+
+
+@app.get("/tests", response_model=TestListResponse)
+async def list_tests() -> TestListResponse:
+    """Return all known tests and their current state."""
+    return await orchestrator.list_tests()
+
+
+@app.post("/tests", response_model=TestSummary, status_code=201)
+async def create_test(config: TestConfig) -> TestSummary:
+    """Create a new test definition."""
+    test = await orchestrator.create_test(config)
+    summary = await test.build_summary()
+    if config.start_immediately:
+        try:
+            summary = await orchestrator.start_test(test.id)
+        except RuntimeError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return summary
+
+
+@app.get("/tests/{test_id}", response_model=TestSummary)
+async def get_test(test_id: UUID) -> TestSummary:
+    """Fetch a specific test summary."""
+    return await _get_test_summary_or_404(test_id)
+
+
+@app.post("/tests/{test_id}/start", response_model=TestSummary)
+async def start_test(test_id: UUID) -> TestSummary:
+    """Begin executing the specified test."""
+    await _get_test_or_404(test_id)
+    try:
+        return await orchestrator.start_test(test_id)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@app.post("/tests/{test_id}/stop", response_model=TestSummary)
+async def stop_test(test_id: UUID) -> TestSummary:
+    """Stop execution of the specified test."""
+    await _get_test_or_404(test_id)
+    try:
+        return await orchestrator.stop_test(test_id)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@app.get("/tests/{test_id}/calls", response_model=CallListResponse)
+async def list_calls(test_id: UUID, limit: int = Query(100, ge=1, le=1000)) -> CallListResponse:
+    """Return recent calls for the selected test."""
+    await _get_test_or_404(test_id)
+    return await orchestrator.list_calls(test_id, limit=limit)
+
+
+@app.post("/callbacks", response_model=CallbackReceipt)
+async def receive_callback(payload: CallbackPayload) -> CallbackReceipt:
+    """Endpoint that downstream services can call with test results."""
+    return await orchestrator.handle_callback(payload)
+
+
+@app.websocket("/ws/tests/{test_id}")
+async def test_updates(websocket: WebSocket, test_id: UUID) -> None:
+    """WebSocket endpoint streaming live test metrics."""
+    try:
+        test = orchestrator.get_test(test_id)
+    except KeyError:
+        await websocket.accept()
+        await websocket.send_json({"error": "Unknown test id."})
+        await websocket.close(code=1008)
+        return
+
+    await websocket.accept()
+    queue = await test.register_subscriber()
+    try:
+        while True:
+            summary = await queue.get()
+            await websocket.send_json(jsonable_encoder(summary))
+    except WebSocketDisconnect:  # pragma: no cover - WebSocket transports aren't exercised in tests
+        pass
+    finally:
+        await test.unregister_subscriber(queue)
+
+
+__all__ = ["app", "orchestrator"]

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,196 @@
+"""Pydantic models and enums used by the load test orchestrator."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field, PositiveInt, root_validator
+from pydantic.networks import AnyHttpUrl
+
+
+class HttpMethod(str, Enum):
+    """Supported HTTP methods for outbound test calls."""
+
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    DELETE = "DELETE"
+
+
+class TestStatus(str, Enum):
+    """Lifecycle status of a load test."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class CallState(str, Enum):
+    """State of an individual orchestrated call."""
+
+    PENDING = "pending"
+    DISPATCHED = "dispatched"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class TestConfig(BaseModel):
+    """Configuration parameters for a load test run."""
+
+    name: str = Field(..., min_length=1, max_length=120)
+    target_url: AnyHttpUrl = Field(..., description="Endpoint under test")
+    method: HttpMethod = Field(HttpMethod.POST, description="HTTP method to use")
+    rate_per_minute: PositiveInt = Field(
+        ...,
+        description="Number of calls per minute to dispatch",
+        ge=1,
+        le=6000,
+    )
+    duration_seconds: PositiveInt = Field(
+        ..., description="How long the test should run", ge=1, le=24 * 60 * 60
+    )
+    headers: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Optional additional headers to include in the outbound call.",
+    )
+    payload: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Optional JSON payload to include with non-GET requests.",
+    )
+    start_immediately: bool = Field(
+        False,
+        description="Whether the orchestrator should immediately start the test after creation.",
+    )
+
+    class Config:
+        extra = "forbid"
+
+
+class TestIdentifier(BaseModel):
+    """Simple model containing a test id."""
+
+    id: UUID = Field(default_factory=uuid4)
+
+
+class CallbackPayload(BaseModel):
+    """Representation of the callback payload received from the tested middleware."""
+
+    correlation_token: str = Field(..., description="Correlation token sent in the request.")
+    status: Optional[str] = Field(
+        None, description="Optional textual status returned by the downstream service."
+    )
+    code: Optional[int] = Field(
+        None,
+        description="Optional numeric status returned by the downstream service.",
+    )
+    detail: Optional[Any] = Field(
+        None, description="Optional payload returned by the downstream service."
+    )
+
+    class Config:
+        extra = "allow"
+
+    SUCCESS_STATUSES = {"success", "ok", "completed", "done"}
+
+    @root_validator(pre=True)
+    def _coerce_correlation_token(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        token = (
+            values.get("correlation_token")
+            or values.get("correlationToken")
+            or values.get("correlation_id")
+            or values.get("correlationId")
+        )
+        if not token:
+            raise ValueError("A correlation token is required on callback payloads.")
+        values["correlation_token"] = token
+        return values
+
+    def is_successful(self) -> Optional[bool]:
+        """Infer whether the callback should be treated as successful."""
+
+        if self.status:
+            lowered = self.status.lower()
+            if lowered in self.SUCCESS_STATUSES:
+                return True
+            if lowered in {"failure", "failed", "error"}:
+                return False
+        if self.code is not None:
+            return 200 <= self.code < 400
+        return None
+
+
+class TestCounts(BaseModel):
+    """Aggregate counter information returned to the client."""
+
+    expected: int
+    sent: int
+    dispatched: int
+    completed: int
+    failed: int
+    pending: int
+
+
+class ResponseTimeMetrics(BaseModel):
+    """Summary metrics for call durations."""
+
+    minimum_ms: Optional[float]
+    maximum_ms: Optional[float]
+    average_ms: Optional[float]
+    median_ms: Optional[float]
+
+
+class TestSummary(BaseModel):
+    """High level overview of a load test."""
+
+    id: UUID
+    name: str
+    status: TestStatus
+    created_at: float
+    started_at: Optional[float]
+    finished_at: Optional[float]
+    counts: TestCounts
+    success_rate: float
+    average_throughput_ms: Optional[float]
+    response_times: ResponseTimeMetrics
+    outstanding_correlation_tokens: List[str] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+
+class TestListResponse(BaseModel):
+    """Response payload for the list tests endpoint."""
+
+    tests: List[TestSummary]
+
+
+class CallRecordSnapshot(BaseModel):
+    """Serializable snapshot of an orchestrated call."""
+
+    correlation_token: str
+    state: CallState
+    sent_at: float
+    ack_status: Optional[int]
+    ack_error: Optional[str]
+    callback_status: Optional[str]
+    callback_code: Optional[int]
+    completed_at: Optional[float]
+    duration_ms: Optional[float]
+
+
+class CallListResponse(BaseModel):
+    """Response payload containing call snapshots."""
+
+    test_id: UUID
+    calls: List[CallRecordSnapshot]
+
+
+class CallbackReceipt(BaseModel):
+    """Response returned when the orchestrator receives a callback."""
+
+    accepted: bool
+    test_id: Optional[UUID]
+    message: str
+

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,0 +1,413 @@
+"""Core orchestration logic for managing load tests."""
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from statistics import mean, median
+from typing import Any, Dict, Iterable, List, Optional, Set
+from uuid import UUID, uuid4
+
+from .models import (
+    CallListResponse,
+    CallRecordSnapshot,
+    CallState,
+    CallbackPayload,
+    CallbackReceipt,
+    HttpMethod,
+    ResponseTimeMetrics,
+    TestConfig,
+    TestCounts,
+    TestListResponse,
+    TestStatus,
+    TestSummary,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class CallRecord:
+    """Mutable state for a single dispatched call."""
+
+    correlation_token: str
+    sent_at: datetime
+    state: CallState = CallState.PENDING
+    ack_status: Optional[int] = None
+    ack_error: Optional[str] = None
+    ack_excerpt: Optional[str] = None
+    callback_status: Optional[str] = None
+    callback_code: Optional[int] = None
+    completed_at: Optional[datetime] = None
+
+    def to_snapshot(self) -> CallRecordSnapshot:
+        return CallRecordSnapshot(
+            correlation_token=self.correlation_token,
+            state=self.state,
+            sent_at=self.sent_at.timestamp(),
+            ack_status=self.ack_status,
+            ack_error=self.ack_error,
+            callback_status=self.callback_status,
+            callback_code=self.callback_code,
+            completed_at=self.completed_at.timestamp() if self.completed_at else None,
+            duration_ms=self.duration_ms,
+        )
+
+    @property
+    def duration_ms(self) -> Optional[float]:
+        if not self.completed_at:
+            return None
+        return (self.completed_at - self.sent_at).total_seconds() * 1000.0
+
+
+class TestRun:
+    """Manages the lifecycle of a single load test execution."""
+
+    def __init__(self, orchestrator: "TestOrchestrator", config: TestConfig, test_id: Optional[UUID] = None) -> None:
+        self.id: UUID = test_id or uuid4()
+        self._orchestrator = orchestrator
+        self.config = config
+        self.status: TestStatus = TestStatus.PENDING
+        self.created_at: datetime = _utcnow()
+        self.started_at: Optional[datetime] = None
+        self.finished_at: Optional[datetime] = None
+        self.error: Optional[str] = None
+        self.calls: Dict[str, CallRecord] = {}
+        self.orphan_callbacks: List[CallbackPayload] = []
+        self._lock = asyncio.Lock()
+        self._stop_event = asyncio.Event()
+        self._task: Optional[asyncio.Task] = None
+        self._subscribers: Set[asyncio.Queue] = set()
+
+    # ------------------------------------------------------------------
+    # Lifecycle management
+    # ------------------------------------------------------------------
+    @property
+    def expected_calls(self) -> int:
+        return math.ceil((self.config.rate_per_minute * self.config.duration_seconds) / 60.0)
+
+    def is_running(self) -> bool:
+        return self.status == TestStatus.RUNNING
+
+    async def start(self) -> None:
+        if self.is_running():
+            raise RuntimeError("Test is already running")
+        if self.status != TestStatus.PENDING:
+            raise RuntimeError(f"Cannot start a test in status {self.status}")
+        self.status = TestStatus.RUNNING
+        self.started_at = _utcnow()
+        self.finished_at = None
+        self.error = None
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run_loop(), name=f"load-test-{self.id}")
+        await self.publish()
+
+    async def stop(self) -> None:
+        if self._task and not self._task.done():
+            self._stop_event.set()
+            await self._task
+        elif self.status == TestStatus.RUNNING:
+            self.status = TestStatus.CANCELLED
+            self.finished_at = _utcnow()
+            await self.publish()
+
+    async def wait_until_complete(self) -> None:
+        if self._task:
+            await self._task
+
+    async def _run_loop(self) -> None:
+        interval_seconds = 60.0 / self.config.rate_per_minute
+        end_time = self.started_at + timedelta(seconds=self.config.duration_seconds)
+        next_dispatch = self.started_at
+        try:
+            async with self._create_http_client() as client:
+                while not self._stop_event.is_set():
+                    now = _utcnow()
+                    if now >= end_time:
+                        break
+                    if now < next_dispatch:
+                        await asyncio.sleep(min(interval_seconds, (next_dispatch - now).total_seconds()))
+                        continue
+                    await self._dispatch_call(client)
+                    next_dispatch += timedelta(seconds=interval_seconds)
+        except Exception as exc:  # pragma: no cover - safety net
+            LOGGER.exception("Unexpected failure in test %s", self.id)
+            self.status = TestStatus.FAILED
+            self.error = str(exc)
+        finally:
+            if self._stop_event.is_set() and self.status != TestStatus.FAILED:
+                self.status = TestStatus.CANCELLED
+            elif self.status == TestStatus.RUNNING:
+                self.status = TestStatus.COMPLETED
+            self.finished_at = _utcnow()
+            await self.publish()
+
+    def _create_http_client(self):
+        try:
+            import httpx
+        except ImportError as exc:  # pragma: no cover - exercised when dependency missing at runtime
+            raise RuntimeError(
+                "httpx is required to dispatch HTTP requests. Install the optional dependency with 'pip install httpx'."
+            ) from exc
+        timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
+        return httpx.AsyncClient(timeout=timeout)
+
+    async def _dispatch_call(self, client: Any) -> None:
+        correlation_token = str(uuid4())
+        record = CallRecord(correlation_token=correlation_token, sent_at=_utcnow())
+        async with self._lock:
+            self.calls[correlation_token] = record
+        self._orchestrator.register_correlation(self.id, correlation_token)
+
+        headers = {**self.config.headers}
+        headers.setdefault("X-Correlation-Token", correlation_token)
+
+        payload: Any
+        if self.config.payload is None:
+            payload = {"correlation_token": correlation_token}
+        else:
+            payload = copy.deepcopy(self.config.payload)
+            if isinstance(payload, dict):
+                payload.setdefault("correlation_token", correlation_token)
+            else:
+                payload = {"payload": payload, "correlation_token": correlation_token}
+
+        request_kwargs: Dict[str, Any] = {
+            "method": self.config.method.value,
+            "url": str(self.config.target_url),
+            "headers": headers,
+        }
+        if self.config.method == HttpMethod.GET:
+            request_kwargs["params"] = payload
+        else:
+            request_kwargs["json"] = payload
+
+        ack_status: Optional[int] = None
+        ack_error: Optional[str] = None
+        new_state = CallState.DISPATCHED
+        completed_at: Optional[datetime] = None
+
+        try:
+            response = await client.request(**request_kwargs)
+            ack_status = response.status_code
+            if response.status_code >= 400:
+                ack_error = f"HTTP {response.status_code}"
+                new_state = CallState.FAILED
+                completed_at = _utcnow()
+                self._orchestrator.unregister_correlation(correlation_token)
+            excerpt = response.text[:256]
+        except Exception as exc:  # pragma: no cover - network failures are exercised in runtime
+            ack_error = str(exc)
+            new_state = CallState.FAILED
+            completed_at = _utcnow()
+            excerpt = None
+            self._orchestrator.unregister_correlation(correlation_token)
+        async with self._lock:
+            stored = self.calls.get(correlation_token)
+            if stored:
+                stored.ack_status = ack_status
+                stored.ack_error = ack_error
+                stored.state = new_state
+                stored.ack_excerpt = excerpt
+                if completed_at and not stored.completed_at:
+                    stored.completed_at = completed_at
+        await self.publish()
+
+    # ------------------------------------------------------------------
+    # Metrics and reporting
+    # ------------------------------------------------------------------
+    async def build_summary(self) -> TestSummary:
+        async with self._lock:
+            calls_snapshot = list(self.calls.values())
+            error_message = self.error
+        durations = [c.duration_ms for c in calls_snapshot if c.duration_ms is not None]
+        completed = sum(1 for c in calls_snapshot if c.state == CallState.COMPLETED)
+        failed = sum(1 for c in calls_snapshot if c.state == CallState.FAILED)
+        dispatched = sum(1 for c in calls_snapshot if c.state in {CallState.DISPATCHED, CallState.COMPLETED})
+        sent = len(calls_snapshot)
+        pending = sent - completed - failed
+        success_rate = (completed / sent * 100.0) if sent else 0.0
+        avg_throughput = mean(durations) if durations else None
+        response_times = ResponseTimeMetrics(
+            minimum_ms=min(durations) if durations else None,
+            maximum_ms=max(durations) if durations else None,
+            average_ms=avg_throughput,
+            median_ms=median(durations) if durations else None,
+        )
+        outstanding = [c.correlation_token for c in calls_snapshot if c.state == CallState.DISPATCHED]
+        summary = TestSummary(
+            id=self.id,
+            name=self.config.name,
+            status=self.status,
+            created_at=self.created_at.timestamp(),
+            started_at=self.started_at.timestamp() if self.started_at else None,
+            finished_at=self.finished_at.timestamp() if self.finished_at else None,
+            counts=TestCounts(
+                expected=self.expected_calls,
+                sent=sent,
+                dispatched=dispatched,
+                completed=completed,
+                failed=failed,
+                pending=max(pending, 0),
+            ),
+            success_rate=success_rate,
+            average_throughput_ms=avg_throughput,
+            response_times=response_times,
+            outstanding_correlation_tokens=outstanding[:50],
+            notes=error_message,
+        )
+        return summary
+
+    async def list_calls(self, limit: int = 100) -> CallListResponse:
+        async with self._lock:
+            calls = list(self.calls.values())
+        calls.sort(key=lambda c: c.sent_at, reverse=True)
+        limited = calls[: limit if limit > 0 else 100]
+        return CallListResponse(test_id=self.id, calls=[c.to_snapshot() for c in limited])
+
+    async def contains_correlation(self, token: str) -> bool:
+        async with self._lock:
+            return token in self.calls
+
+    async def process_callback(self, payload: CallbackPayload) -> bool:
+        async with self._lock:
+            record = self.calls.get(payload.correlation_token)
+            if not record:
+                self.orphan_callbacks.append(payload)
+                matched = False
+            else:
+                record.callback_status = payload.status
+                record.callback_code = payload.code
+                record.completed_at = record.completed_at or _utcnow()
+                inferred = payload.is_successful()
+                if inferred is False:
+                    record.state = CallState.FAILED
+                elif inferred is True:
+                    record.state = CallState.COMPLETED
+                elif record.state != CallState.FAILED:
+                    record.state = CallState.COMPLETED
+                matched = True
+        if matched:
+            self._orchestrator.unregister_correlation(payload.correlation_token)
+        await self.publish()
+        return matched
+
+    # ------------------------------------------------------------------
+    # Websocket helpers
+    # ------------------------------------------------------------------
+    async def register_subscriber(self) -> asyncio.Queue:
+        queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+        self._subscribers.add(queue)
+        summary = await self.build_summary()
+        queue.put_nowait(summary)
+        return queue
+
+    async def unregister_subscriber(self, queue: asyncio.Queue) -> None:
+        self._subscribers.discard(queue)
+
+    async def publish(self) -> None:
+        if not self._subscribers:
+            return
+        summary = await self.build_summary()
+        for queue in list(self._subscribers):
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:  # pragma: no cover - defensive
+                    pass
+            try:
+                queue.put_nowait(summary)
+            except asyncio.QueueFull:  # pragma: no cover - defensive
+                LOGGER.debug("Dropping update for subscriber queue")
+
+
+class TestOrchestrator:
+    """Creates, manages and aggregates the defined load tests."""
+
+    def __init__(self) -> None:
+        self._tests: Dict[UUID, TestRun] = {}
+        self._correlations: Dict[str, UUID] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Test lifecycle
+    # ------------------------------------------------------------------
+    async def create_test(self, config: TestConfig) -> TestRun:
+        test = TestRun(self, config)
+        async with self._lock:
+            self._tests[test.id] = test
+        return test
+
+    def get_test(self, test_id: UUID) -> TestRun:
+        try:
+            return self._tests[test_id]
+        except KeyError as exc:  # pragma: no cover - FastAPI handles HTTP raising
+            raise KeyError(f"Unknown test id {test_id}") from exc
+
+    async def list_tests(self) -> TestListResponse:
+        async with self._lock:
+            runs: Iterable[TestRun] = list(self._tests.values())
+        summaries = [await run.build_summary() for run in sorted(runs, key=lambda r: r.created_at, reverse=True)]
+        return TestListResponse(tests=summaries)
+
+    async def get_summary(self, test_id: UUID) -> TestSummary:
+        run = self.get_test(test_id)
+        return await run.build_summary()
+
+    async def start_test(self, test_id: UUID) -> TestSummary:
+        run = self.get_test(test_id)
+        await run.start()
+        return await run.build_summary()
+
+    async def stop_test(self, test_id: UUID) -> TestSummary:
+        run = self.get_test(test_id)
+        await run.stop()
+        return await run.build_summary()
+
+    async def list_calls(self, test_id: UUID, limit: int = 100) -> CallListResponse:
+        run = self.get_test(test_id)
+        return await run.list_calls(limit)
+
+    # ------------------------------------------------------------------
+    # Correlation handling
+    # ------------------------------------------------------------------
+    def register_correlation(self, test_id: UUID, correlation_token: str) -> None:
+        self._correlations[correlation_token] = test_id
+
+    def unregister_correlation(self, correlation_token: str) -> None:
+        self._correlations.pop(correlation_token, None)
+
+    async def handle_callback(self, payload: CallbackPayload) -> CallbackReceipt:
+        test_id = self._correlations.get(payload.correlation_token)
+        target_run: Optional[TestRun] = None
+        if test_id:
+            target_run = self._tests.get(test_id)
+        if not target_run:
+            for run in self._tests.values():
+                if await run.contains_correlation(payload.correlation_token):
+                    target_run = run
+                    test_id = run.id
+                    break
+        if not target_run:
+            return CallbackReceipt(
+                accepted=False,
+                test_id=None,
+                message="Correlation token was not recognized by any active test.",
+            )
+        accepted = await target_run.process_callback(payload)
+        message = "Callback processed." if accepted else "Callback did not match any call in the target test."
+        return CallbackReceipt(accepted=accepted, test_id=test_id, message=message)
+
+
+__all__ = [
+    "TestOrchestrator",
+    "TestRun",
+    "CallRecord",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "la-loadtest"
+version = "0.1.0"
+description = "Load testing orchestrator for middleware services"
+authors = [
+    {name = "Load Testing Toolkit"},
+]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110,<1.0",
+    "uvicorn[standard]>=0.24,<1.0",
+    "httpx>=0.27,<0.28",
+    "pydantic>=1.10,<3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "pytest-asyncio>=0.23",
+]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is available on sys.path so that "app" can be imported
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,104 @@
+import asyncio
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+import pytest
+
+from app.models import CallState, CallbackPayload, HttpMethod, TestConfig, TestStatus
+from app.orchestrator import CallRecord, TestOrchestrator, TestRun, _utcnow
+
+
+def test_run_lifecycle_and_metrics(monkeypatch):
+    async def scenario():
+        orchestrator = TestOrchestrator()
+        dispatched_tokens = []
+
+        async def fake_dispatch(self: TestRun, client):
+            token = str(uuid4())
+            record = CallRecord(correlation_token=token, sent_at=_utcnow(), state=CallState.DISPATCHED)
+            async with self._lock:
+                self.calls[token] = record
+            self._orchestrator.register_correlation(self.id, token)
+            dispatched_tokens.append(token)
+            await self.publish()
+
+        monkeypatch.setattr(TestRun, "_dispatch_call", fake_dispatch)
+
+        @asynccontextmanager
+        async def fake_client():
+            class DummyClient:
+                async def request(self, **kwargs):  # pragma: no cover - should not be called in this test
+                    raise AssertionError("HTTP requests should not be executed in the unit test")
+
+            yield DummyClient()
+
+        monkeypatch.setattr(TestRun, "_create_http_client", lambda self: fake_client())
+
+        config = TestConfig(
+            name="demo",
+            target_url="https://example.org/api",
+            method=HttpMethod.POST,
+            rate_per_minute=120,
+            duration_seconds=1,
+            payload={"hello": "world"},
+        )
+        test = await orchestrator.create_test(config)
+
+        assert test.status == TestStatus.PENDING
+
+        await orchestrator.start_test(test.id)
+        await test.wait_until_complete()
+
+        summary = await orchestrator.get_summary(test.id)
+        assert summary.status == TestStatus.COMPLETED
+        assert summary.counts.sent == len(dispatched_tokens)
+        assert summary.counts.completed == 0
+        assert summary.counts.pending == summary.counts.sent
+
+        # Process callback for the first token and ensure metrics update
+        first_token = dispatched_tokens[0]
+        receipt = await orchestrator.handle_callback(CallbackPayload(correlation_token=first_token, status="success"))
+        assert receipt.accepted is True
+        updated = await orchestrator.get_summary(test.id)
+        assert updated.counts.completed == 1
+        assert updated.success_rate >= 50.0
+        assert first_token not in updated.outstanding_correlation_tokens
+
+        # Remaining tokens should still be pending
+        if len(dispatched_tokens) > 1:
+            assert any(token in updated.outstanding_correlation_tokens for token in dispatched_tokens[1:])
+
+        # list_calls should expose the recorded dispatches
+        call_listing = await orchestrator.list_calls(test.id, limit=10)
+        assert call_listing.test_id == test.id
+        assert len(call_listing.calls) == len(dispatched_tokens)
+
+        # Unmatched callbacks should not be accepted
+        receipt = await orchestrator.handle_callback(CallbackPayload(correlation_token="missing", status="success"))
+        assert receipt.accepted is False
+        assert receipt.test_id is None
+
+        # Attempting to start again should raise a runtime error
+        with pytest.raises(RuntimeError):
+            await orchestrator.start_test(test.id)
+
+    asyncio.run(scenario())
+
+
+def test_list_tests_contains_created_runs():
+    async def scenario():
+        orchestrator = TestOrchestrator()
+
+        config = TestConfig(
+            name="another",
+            target_url="https://example.org/api",
+            method=HttpMethod.GET,
+            rate_per_minute=60,
+            duration_seconds=10,
+        )
+        test = await orchestrator.create_test(config)
+
+        listing = await orchestrator.list_tests()
+        assert any(item.id == test.id for item in listing.tests)
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- build a FastAPI application that exposes endpoints and WebSocket feeds for orchestrated load tests
- implement the in-memory orchestrator, data models, and scheduling logic to drive correlated requests and collect metrics
- document setup steps and add tests that exercise the orchestrator lifecycle and metrics reporting

## Testing
- `pytest` *(fails: missing pydantic dependency because packages could not be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd78e209ac832892400b7be61e3d33