### PR TITLE
Add web dashboard for load test monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ tests/
 
 4. **Interact with the API:**
    - Open the automatically generated API docs at `http://localhost:8000/docs` to explore and invoke endpoints.
+   - Launch the real-time dashboard at `http://localhost:8000/ui` to create tests and monitor them through a graphical interface.
    - Use the `/tests` endpoints to create, start, stop, and inspect load tests.
    - Subscribe to real-time updates via WebSocket at `ws://localhost:8000/ws/tests/{test_id}`.
    - Point your downstream service callbacks to `POST http://localhost:8000/callbacks` and include the `correlation_token` returned in each outbound request.
@@ -99,6 +100,18 @@ Connect to the WebSocket endpoint for a test to receive periodic JSON payloads c
 - Outstanding correlation tokens that are still awaiting callbacks (truncated to 50 entries)
 
 These updates can be used to power dashboards or feed alerting workflows during a load test.
+
+### Using the built-in dashboard
+
+The repository bundles a single-page application that gives you a visual overview of the orchestrator. After the API is running, navigate to `http://localhost:8000/ui` to:
+
+- Inspect all configured tests, including their status, call counts, success rate, and response-time statistics.
+- Start, stop, and refresh tests without leaving the page.
+- Watch live metrics that stream in over WebSockets, with automatic refresh of recent call activity.
+- Review outstanding correlation tokens and recent callback activity.
+- Create new tests with a guided form that accepts headers, payload JSON, and an option to start immediately.
+
+The dashboard automatically reconnects to the WebSocket feed when you switch between tests so you can keep the UI open while a test is in progress.
 
 ## Running tests
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,13 @@
 """FastAPI application exposing the load test orchestrator."""
 from __future__ import annotations
 
+from pathlib import Path
 from uuid import UUID
 
 from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
 from fastapi.encoders import jsonable_encoder
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from . import __version__
 from .models import (
@@ -19,6 +22,10 @@ from .orchestrator import TestOrchestrator
 
 app = FastAPI(title="Middleware Load Test Orchestrator", version=__version__)
 orchestrator = TestOrchestrator()
+STATIC_DIR = Path(__file__).parent / "static"
+
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 
 async def _get_test_summary_or_404(test_id: UUID) -> TestSummary:
@@ -39,6 +46,20 @@ async def _get_test_or_404(test_id: UUID):
 async def root() -> dict:
     """Basic health endpoint."""
     return {"service": app.title, "version": app.version}
+
+
+@app.get("/ui", include_in_schema=False)
+async def serve_ui() -> FileResponse:
+    """Serve the bundled single-page application."""
+
+    if not STATIC_DIR.exists():  # pragma: no cover - only triggered if assets are missing
+        raise HTTPException(status_code=404, detail="The web interface is not available.")
+
+    index_path = STATIC_DIR / "index.html"
+    if not index_path.exists():  # pragma: no cover - only triggered if assets are missing
+        raise HTTPException(status_code=404, detail="The web interface is not available.")
+
+    return FileResponse(index_path)
 
 
 @app.get("/tests", response_model=TestListResponse)

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,723 @@
+(function () {
+  const state = {
+    tests: [],
+    selectedTestId: null,
+    currentSummary: null,
+    ws: null,
+    statusTimer: null,
+    lastCallRefresh: 0,
+    callRefreshTimer: null,
+  };
+
+  const DEFAULT_STATUS = 'Ready.';
+  const STATUS_RESET_DELAY = 4000;
+  const CALL_REFRESH_MIN_INTERVAL = 5000;
+
+  const numberFormatter = new Intl.NumberFormat();
+  const percentFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
+  const durationFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
+
+  const statusBanner = document.getElementById('status-banner');
+  const testsListEl = document.getElementById('tests-list');
+  const testsEmptyStateEl = document.getElementById('tests-empty-state');
+  const testDetailsPlaceholder = document.getElementById('test-details');
+  const summarySection = document.getElementById('summary-section');
+  const summaryNameEl = document.getElementById('summary-name');
+  const summaryStatusEl = document.getElementById('summary-status');
+  const summaryCreatedEl = document.getElementById('summary-created');
+  const summaryStartedWrapper = document.getElementById('summary-started-wrapper');
+  const summaryStartedEl = document.getElementById('summary-started');
+  const summaryFinishedWrapper = document.getElementById('summary-finished-wrapper');
+  const summaryFinishedEl = document.getElementById('summary-finished');
+  const summarySuccessRateEl = document.getElementById('summary-success-rate');
+  const summaryThroughputEl = document.getElementById('summary-throughput');
+  const summaryNotesWrapper = document.getElementById('notes-wrapper');
+  const summaryNotesEl = document.getElementById('summary-notes');
+  const outstandingWrapper = document.getElementById('outstanding-wrapper');
+  const outstandingListEl = document.getElementById('outstanding-list');
+  const callsContainer = document.getElementById('calls-container');
+  const actionsRow = document.getElementById('test-actions');
+  const refreshTestsBtn = document.getElementById('refresh-tests');
+  const refreshSummaryBtn = document.getElementById('refresh-summary');
+  const refreshCallsBtn = document.getElementById('refresh-calls');
+  const startButton = document.getElementById('start-test');
+  const stopButton = document.getElementById('stop-test');
+  const createTestForm = document.getElementById('create-test-form');
+  const apiBaseEl = document.getElementById('api-base');
+  const appVersionEl = document.getElementById('app-version');
+
+  const countElements = {
+    expected: document.getElementById('count-expected'),
+    sent: document.getElementById('count-sent'),
+    dispatched: document.getElementById('count-dispatched'),
+    completed: document.getElementById('count-completed'),
+    failed: document.getElementById('count-failed'),
+    pending: document.getElementById('count-pending'),
+  };
+
+  const responseTimeElements = {
+    minimum_ms: document.getElementById('rt-min'),
+    median_ms: document.getElementById('rt-median'),
+    average_ms: document.getElementById('rt-average'),
+    maximum_ms: document.getElementById('rt-max'),
+  };
+
+  function setStatus(message, type = 'info', options = {}) {
+    const { persist = false } = options;
+    statusBanner.textContent = message;
+    statusBanner.dataset.type = type;
+
+    if (state.statusTimer) {
+      clearTimeout(state.statusTimer);
+      state.statusTimer = null;
+    }
+
+    if (!persist) {
+      state.statusTimer = window.setTimeout(() => {
+        statusBanner.textContent = DEFAULT_STATUS;
+        statusBanner.dataset.type = 'info';
+        state.statusTimer = null;
+      }, STATUS_RESET_DELAY);
+    }
+  }
+
+  function formatStatus(status) {
+    if (!status) {
+      return 'Unknown';
+    }
+    return status.charAt(0).toUpperCase() + status.slice(1);
+  }
+
+  function formatTimestamp(seconds) {
+    if (seconds === null || seconds === undefined) {
+      return '—';
+    }
+    const date = new Date(seconds * 1000);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+    return date.toLocaleString();
+  }
+
+  function formatDuration(value) {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+    return `${durationFormatter.format(value)} ms`;
+  }
+
+  function formatThroughput(value) {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+    return `${durationFormatter.format(value)} ms`;
+  }
+
+  async function requestJSON(url, options = {}) {
+    const { method = 'GET', body } = options;
+    const fetchOptions = {
+      method,
+      headers: {
+        Accept: 'application/json',
+      },
+    };
+
+    if (body !== undefined) {
+      fetchOptions.headers['Content-Type'] = 'application/json';
+      fetchOptions.body = JSON.stringify(body);
+    }
+
+    let response;
+    try {
+      response = await fetch(url, fetchOptions);
+    } catch (error) {
+      throw new Error(`Network error: ${error.message}`);
+    }
+
+    const text = await response.text();
+    let data = null;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch (error) {
+        throw new Error('Received an unexpected response from the server.');
+      }
+    }
+
+    if (!response.ok) {
+      const detail = data && data.detail;
+      if (typeof detail === 'string' && detail.trim()) {
+        throw new Error(detail);
+      }
+      if (Array.isArray(detail)) {
+        throw new Error(detail.join(', '));
+      }
+      if (data && typeof data.message === 'string') {
+        throw new Error(data.message);
+      }
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+
+    return data;
+  }
+
+  function renderTestList() {
+    testsListEl.innerHTML = '';
+
+    if (!state.tests.length) {
+      testsEmptyStateEl.classList.remove('hidden');
+      return;
+    }
+
+    testsEmptyStateEl.classList.add('hidden');
+
+    state.tests.forEach((summary) => {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'test-item';
+      if (summary.id === state.selectedTestId) {
+        button.classList.add('selected');
+      }
+
+      const info = document.createElement('div');
+      info.className = 'item-info';
+
+      const title = document.createElement('div');
+      title.className = 'item-title';
+      title.textContent = summary.name;
+      info.appendChild(title);
+
+      const subtitle = document.createElement('div');
+      subtitle.className = 'item-subtitle';
+      subtitle.textContent = `${numberFormatter.format(summary.counts.sent)} sent · ${numberFormatter.format(
+        summary.counts.completed,
+      )} completed · ${numberFormatter.format(summary.counts.pending)} pending`;
+      info.appendChild(subtitle);
+
+      const status = document.createElement('span');
+      status.className = 'status-pill';
+      status.dataset.status = summary.status;
+      status.textContent = formatStatus(summary.status);
+
+      button.appendChild(info);
+      button.appendChild(status);
+      button.addEventListener('click', () => {
+        selectTest(summary.id);
+      });
+
+      item.appendChild(button);
+      testsListEl.appendChild(item);
+    });
+  }
+
+  function clearSummary() {
+    state.currentSummary = null;
+    summarySection.classList.add('hidden');
+    actionsRow.classList.add('hidden');
+    testDetailsPlaceholder.classList.remove('hidden');
+    testDetailsPlaceholder.textContent = state.tests.length
+      ? 'Select a test to see the latest metrics.'
+      : 'Create a test to begin monitoring.';
+    outstandingListEl.innerHTML = '';
+    outstandingWrapper.classList.add('hidden');
+    summaryNotesWrapper.classList.add('hidden');
+    callsContainer.innerHTML = '<p class="muted">Select a test to view recent call activity.</p>';
+    document.title = 'Middleware Load Test Dashboard';
+  }
+
+  function updateSummary(summary, options = {}) {
+    const { fromWebSocket = false, updateList = true } = options;
+    const previousCounts = state.currentSummary && state.currentSummary.counts;
+
+    state.currentSummary = summary;
+    summarySection.classList.remove('hidden');
+    actionsRow.classList.remove('hidden');
+    testDetailsPlaceholder.classList.add('hidden');
+
+    summaryNameEl.textContent = summary.name;
+    summaryStatusEl.dataset.status = summary.status;
+    summaryStatusEl.textContent = formatStatus(summary.status);
+    summaryCreatedEl.textContent = formatTimestamp(summary.created_at);
+
+    if (summary.started_at) {
+      summaryStartedWrapper.classList.remove('hidden');
+      summaryStartedEl.textContent = formatTimestamp(summary.started_at);
+    } else {
+      summaryStartedWrapper.classList.add('hidden');
+      summaryStartedEl.textContent = '';
+    }
+
+    if (summary.finished_at) {
+      summaryFinishedWrapper.classList.remove('hidden');
+      summaryFinishedEl.textContent = formatTimestamp(summary.finished_at);
+    } else {
+      summaryFinishedWrapper.classList.add('hidden');
+      summaryFinishedEl.textContent = '';
+    }
+
+    countElements.expected.textContent = numberFormatter.format(summary.counts.expected);
+    countElements.sent.textContent = numberFormatter.format(summary.counts.sent);
+    countElements.dispatched.textContent = numberFormatter.format(summary.counts.dispatched);
+    countElements.completed.textContent = numberFormatter.format(summary.counts.completed);
+    countElements.failed.textContent = numberFormatter.format(summary.counts.failed);
+    countElements.pending.textContent = numberFormatter.format(summary.counts.pending);
+
+    summarySuccessRateEl.textContent = `${percentFormatter.format(summary.success_rate)}%`;
+    summaryThroughputEl.textContent = formatThroughput(summary.average_throughput_ms);
+
+    Object.entries(responseTimeElements).forEach(([key, element]) => {
+      element.textContent = formatDuration(summary.response_times[key]);
+    });
+
+    if (summary.outstanding_correlation_tokens && summary.outstanding_correlation_tokens.length) {
+      outstandingWrapper.classList.remove('hidden');
+      outstandingListEl.innerHTML = '';
+      summary.outstanding_correlation_tokens.forEach((token) => {
+        const li = document.createElement('li');
+        li.textContent = token;
+        outstandingListEl.appendChild(li);
+      });
+    } else {
+      outstandingWrapper.classList.add('hidden');
+      outstandingListEl.innerHTML = '';
+    }
+
+    if (summary.notes) {
+      summaryNotesWrapper.classList.remove('hidden');
+      summaryNotesEl.textContent = summary.notes;
+    } else {
+      summaryNotesWrapper.classList.add('hidden');
+      summaryNotesEl.textContent = '';
+    }
+
+    startButton.disabled = summary.status === 'running';
+    stopButton.disabled = summary.status !== 'running';
+
+    document.title = `Middleware Load Test Dashboard – ${summary.name}`;
+
+    const index = state.tests.findIndex((test) => test.id === summary.id);
+    const shouldRenderList = updateList || index >= 0;
+    if (index >= 0) {
+      state.tests[index] = summary;
+    } else if (updateList) {
+      state.tests.unshift(summary);
+    }
+
+    if (shouldRenderList) {
+      renderTestList();
+    }
+
+    if (
+      fromWebSocket &&
+      previousCounts &&
+      summary.counts &&
+      (summary.counts.completed > previousCounts.completed || summary.counts.failed > previousCounts.failed)
+    ) {
+      maybeRefreshCalls();
+    }
+  }
+
+  function renderCalls(calls) {
+    if (!Array.isArray(calls) || !calls.length) {
+      callsContainer.innerHTML = '<p class="muted">No calls have been recorded yet.</p>';
+      return;
+    }
+
+    const sorted = [...calls].sort((a, b) => (b.sent_at || 0) - (a.sent_at || 0));
+    const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    thead.innerHTML =
+      '<tr><th>Token</th><th>State</th><th>Sent</th><th>Duration (ms)</th><th>Ack</th><th>Callback</th></tr>';
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    sorted.forEach((call) => {
+      const row = document.createElement('tr');
+
+      const tokenCell = document.createElement('td');
+      const tokenCode = document.createElement('code');
+      tokenCode.textContent = call.correlation_token;
+      tokenCode.title = call.correlation_token;
+      tokenCell.appendChild(tokenCode);
+      row.appendChild(tokenCell);
+
+      const stateCell = document.createElement('td');
+      stateCell.textContent = formatStatus(call.state);
+      row.appendChild(stateCell);
+
+      const sentCell = document.createElement('td');
+      sentCell.textContent = formatTimestamp(call.sent_at);
+      row.appendChild(sentCell);
+
+      const durationCell = document.createElement('td');
+      durationCell.textContent = call.duration_ms == null ? '—' : durationFormatter.format(call.duration_ms);
+      row.appendChild(durationCell);
+
+      const ackCell = document.createElement('td');
+      const ackParts = [];
+      if (call.ack_status !== null && call.ack_status !== undefined) {
+        ackParts.push(`Status ${call.ack_status}`);
+      }
+      if (call.ack_error) {
+        ackParts.push(call.ack_error);
+      }
+      ackCell.textContent = ackParts.length ? ackParts.join(' • ') : '—';
+      row.appendChild(ackCell);
+
+      const callbackCell = document.createElement('td');
+      const callbackParts = [];
+      if (call.callback_status) {
+        callbackParts.push(call.callback_status);
+      }
+      if (call.callback_code !== null && call.callback_code !== undefined) {
+        callbackParts.push(`#${call.callback_code}`);
+      }
+      callbackCell.textContent = callbackParts.length ? callbackParts.join(' • ') : '—';
+      row.appendChild(callbackCell);
+
+      tbody.appendChild(row);
+    });
+
+    table.appendChild(tbody);
+    callsContainer.innerHTML = '';
+    callsContainer.appendChild(table);
+  }
+  async function loadCalls(options = {}) {
+    const { silent = false } = options;
+    if (!state.selectedTestId) {
+      return;
+    }
+
+    if (!silent) {
+      setStatus('Loading recent calls…', 'info');
+    }
+
+    try {
+      const response = await requestJSON(`/tests/${state.selectedTestId}/calls?limit=50`);
+      renderCalls(response.calls);
+      state.lastCallRefresh = Date.now();
+      if (state.callRefreshTimer) {
+        clearTimeout(state.callRefreshTimer);
+        state.callRefreshTimer = null;
+      }
+      if (!silent) {
+        setStatus('Recent calls loaded.', 'success');
+      }
+    } catch (error) {
+      if (!silent) {
+        setStatus(`Failed to load calls: ${error.message}`, 'error', { persist: true });
+      }
+    }
+  }
+
+  function maybeRefreshCalls() {
+    const now = Date.now();
+    if (now - state.lastCallRefresh >= CALL_REFRESH_MIN_INTERVAL) {
+      loadCalls({ silent: true });
+    } else {
+      if (state.callRefreshTimer) {
+        clearTimeout(state.callRefreshTimer);
+      }
+      state.callRefreshTimer = window.setTimeout(() => {
+        state.callRefreshTimer = null;
+        loadCalls({ silent: true });
+      }, Math.max(0, CALL_REFRESH_MIN_INTERVAL - (now - state.lastCallRefresh)));
+    }
+  }
+
+  function closeWebSocket() {
+    if (state.ws) {
+      try {
+        state.ws.close(1000, 'Client closing');
+      } catch (error) {
+        console.error('Error closing WebSocket', error);
+      }
+      state.ws = null;
+    }
+  }
+
+  function openWebSocket(testId) {
+    closeWebSocket();
+
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${protocol}://${window.location.host}/ws/tests/${testId}`);
+    state.ws = ws;
+
+    ws.addEventListener('open', () => {
+      setStatus('Live updates connected.', 'success');
+    });
+
+    ws.addEventListener('message', (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        if (payload && payload.error) {
+          setStatus(`Live updates error: ${payload.error}`, 'error', { persist: true });
+          return;
+        }
+        if (payload && payload.id) {
+          updateSummary(payload, { fromWebSocket: true });
+        }
+      } catch (error) {
+        console.error('Failed to parse WebSocket message', error);
+      }
+    });
+
+    ws.addEventListener('close', (event) => {
+      if (!event.wasClean && state.selectedTestId === testId) {
+        setStatus('Live updates disconnected unexpectedly.', 'warning', { persist: true });
+      }
+      if (state.ws === ws) {
+        state.ws = null;
+      }
+    });
+
+    ws.addEventListener('error', () => {
+      setStatus('WebSocket connection reported an error.', 'warning', { persist: true });
+    });
+  }
+
+  async function loadTestSummary(testId) {
+    if (!testId) {
+      return null;
+    }
+
+    try {
+      const summary = await requestJSON(`/tests/${testId}`);
+      updateSummary(summary, { updateList: false });
+      return summary;
+    } catch (error) {
+      setStatus(`Unable to load test: ${error.message}`, 'error', { persist: true });
+      return null;
+    }
+  }
+
+  async function selectTest(testId) {
+    if (!testId) {
+      return;
+    }
+
+    if (state.selectedTestId !== testId) {
+      state.selectedTestId = testId;
+      renderTestList();
+    }
+
+    setStatus('Loading test details…', 'info');
+    const summary = await loadTestSummary(testId);
+    if (!summary) {
+      return;
+    }
+
+    setStatus(`Now viewing “${summary.name}”.`, 'success');
+    await loadCalls({ silent: true });
+    openWebSocket(testId);
+  }
+
+  async function loadTests() {
+    setStatus('Loading tests…', 'info');
+    try {
+      const response = await requestJSON('/tests');
+      const tests = Array.isArray(response.tests) ? response.tests : [];
+      tests.sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+      state.tests = tests;
+      renderTestList();
+      setStatus('Tests loaded.', 'success');
+
+      if (!tests.length) {
+        clearSummary();
+        closeWebSocket();
+        state.selectedTestId = null;
+        return;
+      }
+
+      if (state.selectedTestId) {
+        const matching = tests.find((test) => test.id === state.selectedTestId);
+        if (matching) {
+          updateSummary(matching, { updateList: false });
+        } else {
+          state.selectedTestId = null;
+          clearSummary();
+          closeWebSocket();
+        }
+      }
+
+      if (!state.selectedTestId && tests.length) {
+        state.selectedTestId = tests[0].id;
+        renderTestList();
+        await selectTest(state.selectedTestId);
+      }
+    } catch (error) {
+      setStatus(`Failed to load tests: ${error.message}`, 'error', { persist: true });
+      state.tests = [];
+      renderTestList();
+      clearSummary();
+      closeWebSocket();
+      state.selectedTestId = null;
+    }
+  }
+
+  async function startSelectedTest() {
+    if (!state.selectedTestId) {
+      return;
+    }
+
+    startButton.disabled = true;
+    setStatus('Starting test…', 'info');
+    try {
+      const summary = await requestJSON(`/tests/${state.selectedTestId}/start`, { method: 'POST' });
+      updateSummary(summary);
+      setStatus('Test started.', 'success');
+    } catch (error) {
+      setStatus(`Unable to start test: ${error.message}`, 'error', { persist: true });
+    } finally {
+      startButton.disabled = state.currentSummary ? state.currentSummary.status === 'running' : false;
+    }
+  }
+
+  async function stopSelectedTest() {
+    if (!state.selectedTestId) {
+      return;
+    }
+
+    stopButton.disabled = true;
+    setStatus('Stopping test…', 'info');
+    try {
+      const summary = await requestJSON(`/tests/${state.selectedTestId}/stop`, { method: 'POST' });
+      updateSummary(summary);
+      setStatus('Test stopped.', 'success');
+    } catch (error) {
+      setStatus(`Unable to stop test: ${error.message}`, 'error', { persist: true });
+    } finally {
+      stopButton.disabled = state.currentSummary ? state.currentSummary.status !== 'running' : true;
+    }
+  }
+
+  async function handleRefreshSummary() {
+    if (!state.selectedTestId) {
+      return;
+    }
+
+    setStatus('Refreshing test details…', 'info');
+    const summary = await loadTestSummary(state.selectedTestId);
+    if (summary) {
+      setStatus('Latest metrics loaded.', 'success');
+      await loadCalls({ silent: true });
+    }
+  }
+
+  function parseJsonField(value, fieldName) {
+    if (!value) {
+      return fieldName === 'payload' ? null : {};
+    }
+
+    try {
+      const parsed = JSON.parse(value);
+      if (fieldName === 'headers' && (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed))) {
+        throw new Error('Headers must be a JSON object.');
+      }
+      return parsed;
+    } catch (error) {
+      throw new Error(`Invalid ${fieldName} JSON: ${error.message}`);
+    }
+  }
+
+  async function handleFormSubmit(event) {
+    event.preventDefault();
+
+    const formData = new FormData(createTestForm);
+    const payloadRaw = formData.get('payload');
+    const headersRaw = formData.get('headers');
+
+    let payload;
+    let headers;
+    try {
+      payload = parseJsonField(payloadRaw && payloadRaw.trim(), 'payload');
+      headers = parseJsonField(headersRaw && headersRaw.trim(), 'headers');
+    } catch (error) {
+      setStatus(error.message, 'error', { persist: true });
+      return;
+    }
+
+    const config = {
+      name: String(formData.get('name') || '').trim(),
+      target_url: String(formData.get('target_url') || '').trim(),
+      method: String(formData.get('method') || 'POST'),
+      rate_per_minute: Number(formData.get('rate_per_minute')),
+      duration_seconds: Number(formData.get('duration_seconds')),
+      headers,
+      payload,
+      start_immediately: formData.get('start_immediately') === 'on',
+    };
+
+    if (!config.name || !config.target_url) {
+      setStatus('Name and target URL are required.', 'error', { persist: true });
+      return;
+    }
+
+    const submitButton = createTestForm.querySelector('button[type="submit"]');
+    submitButton.disabled = true;
+    setStatus('Creating test…', 'info');
+
+    try {
+      const summary = await requestJSON('/tests', { method: 'POST', body: config });
+      state.selectedTestId = summary.id;
+      updateSummary(summary);
+      createTestForm.reset();
+      setStatus(`Created test “${summary.name}”.`, 'success');
+      await loadCalls({ silent: true });
+      openWebSocket(summary.id);
+    } catch (error) {
+      setStatus(`Failed to create test: ${error.message}`, 'error', { persist: true });
+    } finally {
+      submitButton.disabled = false;
+    }
+  }
+
+  async function loadServiceInfo() {
+    apiBaseEl.textContent = window.location.origin;
+    try {
+      const info = await requestJSON('/');
+      if (info && info.version) {
+        appVersionEl.textContent = info.version;
+      } else {
+        appVersionEl.textContent = '—';
+      }
+    } catch (error) {
+      appVersionEl.textContent = 'unknown';
+      setStatus(`Unable to reach API service: ${error.message}`, 'warning', { persist: true });
+    }
+  }
+
+  async function init() {
+    clearSummary();
+    renderTestList();
+
+    refreshTestsBtn.addEventListener('click', () => {
+      loadTests();
+    });
+    refreshSummaryBtn.addEventListener('click', () => {
+      handleRefreshSummary();
+    });
+    refreshCallsBtn.addEventListener('click', () => {
+      loadCalls();
+    });
+    startButton.addEventListener('click', () => {
+      startSelectedTest();
+    });
+    stopButton.addEventListener('click', () => {
+      stopSelectedTest();
+    });
+    createTestForm.addEventListener('submit', (event) => {
+      handleFormSubmit(event);
+    });
+
+    window.addEventListener('beforeunload', () => {
+      closeWebSocket();
+    });
+
+    await loadServiceInfo();
+    await loadTests();
+  }
+
+  init();
+})();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Middleware Load Test Dashboard</title>
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+  <header class="banner">
+    <div>
+      <h1>Middleware Load Test Dashboard</h1>
+      <p>Configure, launch, and monitor orchestrated load tests in real time.</p>
+    </div>
+    <div id="status-banner" class="status" data-type="info" role="status" aria-live="polite">Loading…</div>
+  </header>
+  <main class="layout">
+    <section class="panel tests-panel">
+      <div class="panel-header">
+        <h2>Load Tests</h2>
+        <div class="panel-actions">
+          <button id="refresh-tests" class="button button-small" type="button">Refresh</button>
+        </div>
+      </div>
+      <p class="muted" id="tests-empty-state">No tests have been created yet.</p>
+      <ul id="tests-list" class="test-list"></ul>
+    </section>
+    <section class="panel details-panel">
+      <div class="panel-header">
+        <h2>Test Details</h2>
+        <div class="panel-actions button-row hidden" id="test-actions">
+          <button id="refresh-summary" class="button button-small" type="button">Refresh</button>
+          <button id="start-test" class="button button-small button-primary" type="button">Start</button>
+          <button id="stop-test" class="button button-small button-danger" type="button">Stop</button>
+        </div>
+      </div>
+      <div id="test-details" class="muted">Select a test to see the latest metrics.</div>
+      <section id="summary-section" class="hidden">
+        <header class="summary-header">
+          <div>
+            <h3 id="summary-name"></h3>
+            <p class="muted">
+              <span>Created <span id="summary-created"></span></span>
+              <span id="summary-started-wrapper" class="hidden"> • Started <span id="summary-started"></span></span>
+              <span id="summary-finished-wrapper" class="hidden"> • Finished <span id="summary-finished"></span></span>
+            </p>
+          </div>
+          <span id="summary-status" class="status-pill" data-status="pending">Pending</span>
+        </header>
+        <div class="stats-grid">
+          <div class="stat-block">
+            <h4>Call Counts</h4>
+            <dl>
+              <div><dt>Expected</dt><dd id="count-expected">0</dd></div>
+              <div><dt>Sent</dt><dd id="count-sent">0</dd></div>
+              <div><dt>Dispatched</dt><dd id="count-dispatched">0</dd></div>
+              <div><dt>Completed</dt><dd id="count-completed">0</dd></div>
+              <div><dt>Failed</dt><dd id="count-failed">0</dd></div>
+              <div><dt>Pending</dt><dd id="count-pending">0</dd></div>
+            </dl>
+          </div>
+          <div class="stat-block">
+            <h4>Success &amp; Timing</h4>
+            <dl>
+              <div><dt>Success rate</dt><dd id="summary-success-rate">0%</dd></div>
+              <div><dt>Avg throughput</dt><dd id="summary-throughput">—</dd></div>
+              <div><dt>Min duration</dt><dd id="rt-min">—</dd></div>
+              <div><dt>Median duration</dt><dd id="rt-median">—</dd></div>
+              <div><dt>Avg duration</dt><dd id="rt-average">—</dd></div>
+              <div><dt>Max duration</dt><dd id="rt-max">—</dd></div>
+            </dl>
+          </div>
+        </div>
+        <div id="outstanding-wrapper" class="outstanding hidden">
+          <h4>Outstanding Correlation Tokens</h4>
+          <p class="muted">The first 50 tokens awaiting callbacks.</p>
+          <ul id="outstanding-list"></ul>
+        </div>
+        <div id="notes-wrapper" class="notes hidden">
+          <h4>Notes</h4>
+          <p id="summary-notes"></p>
+        </div>
+      </section>
+      <section class="calls-section">
+        <div class="panel-header">
+          <h3>Recent Calls</h3>
+          <div class="panel-actions">
+            <button id="refresh-calls" class="button button-small" type="button">Refresh</button>
+          </div>
+        </div>
+        <div id="calls-container" class="table-container">
+          <p class="muted">Select a test to view recent call activity.</p>
+        </div>
+      </section>
+    </section>
+    <section class="panel form-panel">
+      <h2>Create Load Test</h2>
+      <form id="create-test-form" autocomplete="off">
+        <label>
+          Name
+          <input type="text" name="name" required placeholder="evening-peak">
+        </label>
+        <label>
+          Target URL
+          <input type="url" name="target_url" required placeholder="https://example.com/api/process">
+        </label>
+        <label>
+          Method
+          <select name="method">
+            <option value="POST" selected>POST</option>
+            <option value="GET">GET</option>
+            <option value="PUT">PUT</option>
+            <option value="PATCH">PATCH</option>
+            <option value="DELETE">DELETE</option>
+          </select>
+        </label>
+        <div class="form-row">
+          <label>
+            Rate per minute
+            <input type="number" name="rate_per_minute" min="1" max="6000" required value="60">
+          </label>
+          <label>
+            Duration (seconds)
+            <input type="number" name="duration_seconds" min="1" max="86400" required value="300">
+          </label>
+        </div>
+        <label>
+          Headers (JSON)
+          <textarea name="headers" rows="3" placeholder='{"Ocp-Apim-Subscription-Key": "<subscription-key>"}'></textarea>
+        </label>
+        <label>
+          Payload (JSON)
+          <textarea name="payload" rows="4" placeholder='{"message": "hello from orchestrator"}'></textarea>
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" name="start_immediately">
+          Start immediately
+        </label>
+        <button type="submit" class="button button-primary full-width">Create test</button>
+      </form>
+      <p class="help-text">
+        After creation, select the test from the list to start or stop it and to monitor live metrics.
+        Configure your downstream service to POST callbacks to <code>/callbacks</code> with the correlation token that the orchestrator provides.
+      </p>
+    </section>
+  </main>
+  <footer class="footer">
+    <p>
+      API base URL: <code id="api-base"></code> • Version <span id="app-version">—</span>
+    </p>
+  </footer>
+  <script src="/static/app.js" defer></script>
+</body>
+</html>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,462 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --bg-panel: #ffffff;
+  --bg-muted: #f8fafc;
+  --border: #e2e8f0;
+  --text: #0f172a;
+  --text-muted: #475569;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --danger: #dc2626;
+  --danger-strong: #b91c1c;
+  --success: #15803d;
+  --warning: #f59e0b;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 45%, #0f172a 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.15), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(220, 38, 38, 0.12), transparent 55%);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.banner {
+  position: relative;
+  z-index: 1;
+  padding: 2.5rem clamp(1.5rem, 2vw, 3rem) 1.5rem;
+  color: #f8fafc;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.banner h1 {
+  margin: 0 0 0.25rem;
+  font-size: clamp(1.8rem, 2.8vw, 2.6rem);
+  letter-spacing: -0.01em;
+}
+
+.banner p {
+  margin: 0;
+  max-width: 52ch;
+  color: rgba(248, 250, 252, 0.85);
+  font-size: 1.05rem;
+}
+
+.status {
+  align-self: center;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  min-width: 180px;
+  text-align: center;
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.18);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.status[data-type="info"] {
+  background: rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+}
+
+.status[data-type="success"] {
+  background: rgba(22, 163, 74, 0.25);
+  color: #bbf7d0;
+}
+
+.status[data-type="warning"] {
+  background: rgba(234, 179, 8, 0.25);
+  color: #fef3c7;
+}
+
+.status[data-type="error"] {
+  background: rgba(239, 68, 68, 0.3);
+  color: #fecaca;
+}
+
+.layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 clamp(1.25rem, 2vw, 3rem) 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.panel {
+  background: var(--bg-panel);
+  border-radius: 22px;
+  padding: 1.5rem;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.22);
+  border: 1px solid rgba(226, 232, 240, 0.4);
+  backdrop-filter: blur(4px);
+}
+
+.panel h2 {
+  margin: 0;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.panel-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  appearance: none;
+  border: none;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text);
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.15);
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #fff;
+}
+
+.button-danger {
+  background: linear-gradient(135deg, var(--danger) 0%, var(--danger-strong) 100%);
+  color: #fff;
+}
+
+.button-small {
+  font-size: 0.85rem;
+  padding: 0.45rem 0.85rem;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.muted {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.test-list {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.test-item {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--bg-muted);
+  padding: 0.9rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.test-item:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
+}
+
+.test-item.selected {
+  border-color: var(--accent);
+  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.18);
+}
+
+.test-item .item-title {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.test-item .item-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.status-pill {
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-pill[data-status="pending"] {
+  background: rgba(148, 163, 184, 0.18);
+  color: #1e293b;
+}
+
+.status-pill[data-status="running"] {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--accent-strong);
+}
+
+.status-pill[data-status="completed"] {
+  background: rgba(22, 163, 74, 0.2);
+  color: var(--success);
+}
+
+.status-pill[data-status="failed"] {
+  background: rgba(239, 68, 68, 0.2);
+  color: var(--danger-strong);
+}
+
+.status-pill[data-status="cancelled"] {
+  background: rgba(234, 179, 8, 0.18);
+  color: var(--warning);
+}
+
+.summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.summary-header h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+}
+
+.stats-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+@media (min-width: 780px) {
+  .stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.stat-block {
+  background: var(--bg-muted);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border);
+}
+
+.stat-block h4 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.stat-block dl {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.stat-block dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.stat-block dt {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.stat-block dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.outstanding ul,
+.outstanding-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.outstanding ul li,
+#outstanding-list li {
+  padding: 0.35rem 0;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.outstanding ul li:last-child,
+#outstanding-list li:last-child {
+  border-bottom: none;
+}
+
+.table-container {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--bg-muted);
+}
+
+.table-container table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.table-container th,
+.table-container td {
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+}
+
+.table-container tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.table-container tbody tr:hover {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.table-container td code {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.8rem;
+}
+
+.form-panel form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.form-panel input,
+.form-panel select,
+.form-panel textarea {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: #fff;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-panel input:focus,
+.form-panel select:focus,
+.form-panel textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.checkbox input {
+  width: auto;
+  accent-color: var(--accent);
+}
+
+.help-text {
+  margin-top: 1.5rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.footer {
+  position: relative;
+  z-index: 1;
+  padding: 2rem clamp(1.5rem, 2vw, 3rem) 3rem;
+  color: rgba(248, 250, 252, 0.7);
+  font-size: 0.9rem;
+}
+
+.footer code {
+  background: rgba(148, 163, 184, 0.2);
+  padding: 0.2rem 0.35rem;
+  border-radius: 6px;
+  color: #f8fafc;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (min-width: 1100px) {
+  .details-panel {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 720px) {
+  .banner {
+    padding-bottom: 2.5rem;
+  }
+
+  .status {
+    width: 100%;
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "uvicorn[standard]>=0.24,<1.0",
     "httpx>=0.27,<0.28",
     "pydantic>=1.10,<3.0",
+    "aiofiles>=23.2,<24.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- expose the new dashboard at `/ui` and mount bundled static assets from the FastAPI app
- add a single-page interface with metrics panels, recent call views, and a form to create tests, plus supporting styles and interactivity
- document the dashboard workflow in the README and add the aiofiles dependency required for serving static files

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic' because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7cb22b448328b8304fc5c5b8e4e1